### PR TITLE
fix WOWSims Json import text length

### DIFF
--- a/GUI.lua
+++ b/GUI.lua
@@ -771,6 +771,7 @@ function GUI.CreateStaticPopup(name, text, options)
     button2 = CANCEL,
     hasEditBox = true,
     editBoxWidth = 350,
+    maxLetters = 10000,
     OnAccept = function (self)
       options.func(self.editBox:GetText ())
     end,


### PR DESCRIPTION
For some reason you can suddenly only paste strings of default length 30 in Cata. This additional parameter allows Json strings up to 10000 characters.